### PR TITLE
Insert missing '0' for DEFAULT_MAPSIZE (consistent w/ documentation, …

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -617,7 +617,7 @@ typedef uint16_t	 indx_t;
 	 *	This is certainly too small for any actual applications. Apps should always set
 	 *	the size explicitly using #mdb_env_set_mapsize().
 	 */
-#define DEFAULT_MAPSIZE	1048576
+#define DEFAULT_MAPSIZE	10485760
 
 /**	@defgroup readers	Reader Lock Table
  *	Readers don't acquire any locks for their data access. Instead, they


### PR DESCRIPTION
…and nice 'round' number).