### PR TITLE
Fix robust mutex detection for glibc 2.10 and 2.11

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -300,8 +300,8 @@ union semun {
 #  define MDB_USE_ROBUST	0
 # else
 #  define MDB_USE_ROBUST	1
-/* glibc < 2.10 only provided _np API */
-#  if defined(__GLIBC__) && GLIBC_VER < 0x02000a
+/* glibc < 2.12 only provided _np API */
+#  if defined(__GLIBC__) && GLIBC_VER < 0x02000c
 #   define PTHREAD_MUTEX_ROBUST	PTHREAD_MUTEX_ROBUST_NP
 #   define pthread_mutexattr_setrobust(attr, flag)	pthread_mutexattr_setrobust_np(attr, flag)
 #   define pthread_mutex_consistent(mutex)	pthread_mutex_consistent_np(mutex)


### PR DESCRIPTION
`pthread_mutexattr_setrobust` and `pthread_mutex_consistent` are provided since `2.12` not `2.10`:
- https://github.molgen.mpg.de/git-mirror/glibc/commit/402cd98775db1478f64c9b0dbe00664b89eb2773
- https://github.molgen.mpg.de/git-mirror/glibc/commit/78ee21859939ff75ccf8bbe00499b0c462df2e2d

When compiling the project under Ubuntu Lucid (glibc `2.11`), I get the following errors:
```
$ make
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized   -c mdb.c
mdb.c: In function 'mdb_mutex_failed':
mdb.c:10137: warning: implicit declaration of function 'pthread_mutex_consistent'
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized   -c midl.c
ar rs liblmdb.a mdb.o midl.o
ar: creating liblmdb.a
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized  -fPIC  -c mdb.c -o mdb.lo
mdb.c: In function 'mdb_mutex_failed':
mdb.c:10137: warning: implicit declaration of function 'pthread_mutex_consistent'
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized  -fPIC  -c midl.c -o midl.lo
gcc  -pthread -shared -o liblmdb.so mdb.lo midl.lo
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized   -c mdb_stat.c
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized   mdb_stat.o liblmdb.a  -o mdb_stat
liblmdb.a(mdb.o): In function `mdb_mutex_failed':
/home/vagrant/lmdb/libraries/liblmdb/mdb.c:10137: undefined reference to `pthread_mutex_consistent'
liblmdb.a(mdb.o): In function `mdb_env_setup_locks':
/home/vagrant/lmdb/libraries/liblmdb/mdb.c:4752: undefined reference to `pthread_mutexattr_setrobust'
collect2: ld returned 1 exit status
make: *** [mdb_stat] Error 1
```

The exact version of the glibc is the following:
```
$ ldd --version
ldd (Ubuntu EGLIBC 2.11.1-0ubuntu7.21) 2.11.1
Copyright (C) 2009 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 10.04.4 LTS
Release:	10.04
Codename:	lucid
```

After applying the provided fix, the compilation and runtime is working properly.