### PR TITLE
nmake makefile + support for console tools on Windows

### DIFF
--- a/libraries/liblmdb/Makefile.vc
+++ b/libraries/liblmdb/Makefile.vc
@@ -1,0 +1,60 @@
+
+
+CC=cl.exe
+AR=lib.exe
+
+CFLAGS = /nologo /I win32 /Zi /MD /guard:cf /Zc:inline /Ox /W3 /GF /GL /Gw
+
+PREFIX=install
+
+LIBS=liblmdb_a.lib
+PROGS=mdb_copy.exe mdb_load.exe mdb_stat.exe mdb_dump.exe
+
+all: $(LIBS) $(PROGS)
+
+install: all
+	if not exist $(PREFIX)\bin mkdir $(PREFIX)\bin
+	if not exist $(PREFIX)\lib mkdir $(PREFIX)\lib
+	if not exist $(PREFIX)\include mkdir $(PREFIX)\include
+	copy /Y lmdb.h $(PREFIX)\include
+	copy /Y liblmdb_a.lib $(PREFIX)\lib
+	copy /Y liblmdb_a.pdb $(PREFIX)\lib
+	copy /Y mdb_copy.exe $(PREFIX)\bin
+	copy /Y mdb_load.exe $(PREFIX)\bin
+	copy /Y mdb_stat.exe $(PREFIX)\bin
+	copy /Y mdb_dump.exe $(PREFIX)\bin
+
+clean:
+	del *.obj *.lib *.exe
+
+mdb.obj: mdb.c lmdb.h midl.h
+	$(CC) $(CFLAGS) /Fdliblmdb_a.pdb /c mdb.c
+
+midl.obj: midl.c midl.h
+	$(CC) $(CFLAGS) /Fdliblmdb_a.pdb /c midl.c
+
+liblmdb_a.lib: mdb.obj midl.obj
+	$(AR) /nologo mdb.obj midl.obj /OUT:liblmdb_a.lib
+
+getopt.obj: win32/getopt.c
+	$(CC) $(CFLAGS) /c win32/getopt.c
+
+mdb_copy.exe: getopt.obj liblmdb_a.lib
+	$(CC) $(CFLAGS) mdb_copy.c /link liblmdb_a.lib ntdll.lib advapi32.lib
+
+mdb_load.exe: getopt.obj liblmdb_a.lib
+	$(CC) $(CFLAGS) mdb_load.c /link getopt.obj liblmdb_a.lib ntdll.lib advapi32.lib
+
+mdb_stat.exe: getopt.obj liblmdb_a.lib
+	$(CC) $(CFLAGS) mdb_stat.c /link getopt.obj liblmdb_a.lib ntdll.lib advapi32.lib
+
+mdb_dump.exe: getopt.obj liblmdb_a.lib
+	$(CC) $(CFLAGS) mdb_dump.c /link getopt.obj liblmdb_a.lib ntdll.lib advapi32.lib
+
+test: all
+	$(CC) $(CFLAGS) mtest.c /link liblmdb_a.lib ntdll.lib advapi32.lib
+	if exist testdb del /s /f /q testdb\*.*
+	if exist testdb rmdir testdb
+	mkdir testdb
+	mtest && mdb_stat testdb
+	

--- a/libraries/liblmdb/win32/getopt.c
+++ b/libraries/liblmdb/win32/getopt.c
@@ -1,0 +1,75 @@
+/*
+POSIX getopt for Windows
+
+AT&T Public License
+
+Code given out at the 1985 UNIFORUM conference in Dallas.  
+*/
+
+#ifndef __GNUC__
+
+#include "getopt.h"
+#include <stdio.h>
+#include <string.h>
+
+#define NULL	0
+#define EOF	(-1)
+#define ERR(s, c)	if(opterr){\
+	char errbuf[2];\
+	errbuf[0] = c; errbuf[1] = '\n';\
+	fputs(argv[0], stderr);\
+	fputs(s, stderr);\
+	fputc(c, stderr);}
+	//(void) write(2, argv[0], (unsigned)strlen(argv[0]));\
+	//(void) write(2, s, (unsigned)strlen(s));\
+	//(void) write(2, errbuf, 2);}
+
+int	opterr = 1;
+int	optind = 1;
+int	optopt;
+char	*optarg;
+
+int getopt(int argc, char **argv, char *opts)
+{
+	static int sp = 1;
+	register int c;
+	register char *cp;
+
+	if(sp == 1)
+		if(optind >= argc ||
+		   argv[optind][0] != '-' || argv[optind][1] == '\0')
+			return(EOF);
+		else if(strcmp(argv[optind], "--") == NULL) {
+			optind++;
+			return(EOF);
+		}
+	optopt = c = argv[optind][sp];
+	if(c == ':' || (cp=strchr(opts, c)) == NULL) {
+		ERR(": illegal option -- ", c);
+		if(argv[optind][++sp] == '\0') {
+			optind++;
+			sp = 1;
+		}
+		return('?');
+	}
+	if(*++cp == ':') {
+		if(argv[optind][sp+1] != '\0')
+			optarg = &argv[optind++][sp+1];
+		else if(++optind >= argc) {
+			ERR(": option requires an argument -- ", c);
+			sp = 1;
+			return('?');
+		} else
+			optarg = argv[optind++];
+		sp = 1;
+	} else {
+		if(argv[optind][++sp] == '\0') {
+			sp = 1;
+			optind++;
+		}
+		optarg = NULL;
+	}
+	return(c);
+}
+
+#endif  /* __GNUC__ */

--- a/libraries/liblmdb/win32/getopt.h
+++ b/libraries/liblmdb/win32/getopt.h
@@ -1,0 +1,32 @@
+/*
+POSIX getopt for Windows
+
+AT&T Public License
+
+Code given out at the 1985 UNIFORUM conference in Dallas.  
+*/
+
+#ifdef __GNUC__
+#include <getopt.h>
+#endif
+#ifndef __GNUC__
+
+#ifndef _WINGETOPT_H_
+#define _WINGETOPT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int opterr;
+extern int optind;
+extern int optopt;
+extern char *optarg;
+extern int getopt(int argc, char **argv, char *opts);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _GETOPT_H_ */
+#endif  /* __GNUC__ */

--- a/libraries/liblmdb/win32/unistd.h
+++ b/libraries/liblmdb/win32/unistd.h
@@ -1,0 +1,7 @@
+
+#include <stdint.h>
+
+typedef intptr_t ssize_t;
+
+#include "getopt.h"
+


### PR DESCRIPTION
Things done

- add Makefile.vc
- add surrogate code for getopt, etc.

It is a very basic work yet, which can be improved. For simplicity, the lowest version supported is VC12, lower can likely be supported as well by removing some flags, if needed. There are still some compilation warnings, which can be ignored for now, the PR targets only the basic build support. All the tests look good so far.

thanks.