### PR TITLE
Feature/fix cppcheck issues

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -8237,9 +8237,12 @@ mdb_leaf_size(MDB_env *env, MDB_val *key, MDB_val *data)
 {
 	size_t		 sz;
 
+	// cppcheck-suppress nullPointer ; cppcheck mistake: mdb_leaf_size() is NOT called with data == nullptr
+	// cppcheck-suppress ctunullpointer ; same reason
 	sz = LEAFSIZE(key, data);
 	if (sz > env->me_nodemax) {
 		/* put on overflow page */
+		// cppcheck-suppress nullPointer ; cppcheck mistake: mdb_leaf_size() is NOT called with data == nullptr
 		sz -= data->mv_size - sizeof(pgno_t);
 	}
 
@@ -8333,6 +8336,7 @@ mdb_node_add(MDB_cursor *mc, indx_t indx,
 		if (F_ISSET(flags, F_BIGDATA)) {
 			/* Data already on overflow page. */
 			node_size += sizeof(pgno_t);
+		// cppcheck-suppress nullPointer ; (IS_LEAF(mp) == True) => (data != nulllptr)
 		} else if (node_size + data->mv_size > mc->mc_txn->mt_env->me_nodemax) {
 			int ovpages = OVPAGES(data->mv_size, mc->mc_txn->mt_env->me_psize);
 			int rc;
@@ -9751,6 +9755,7 @@ mdb_page_split(MDB_cursor *mc, MDB_val *newkey, MDB_val *newdata, pgno_t newpgno
 			/* Maximum free space in an empty page */
 			pmax = env->me_psize - PAGEHDRSZ;
 			if (IS_LEAF(mp))
+				// cppcheck-suppress nullPointer ; (IS_LEAF(mp) == True) => (data != newdata)
 				nsize = mdb_leaf_size(env, newkey, newdata);
 			else
 				nsize = mdb_branch_size(env, newkey);

--- a/libraries/liblmdb/midl.c
+++ b/libraries/liblmdb/midl.c
@@ -132,8 +132,10 @@ static int mdb_midl_grow( MDB_IDL *idp, int num )
 {
 	MDB_IDL idn = *idp-1;
 	/* grow it */
+	MDB_IDL idn_copy = idn;
 	idn = realloc(idn, (*idn + num + 2) * sizeof(MDB_ID));
 	if (!idn)
+		free(idn_copy);		// Avoid potential memory leak when realloc() returns nullptr
 		return ENOMEM;
 	*idn++ += num;
 	*idp = idn;


### PR DESCRIPTION
Happy to contribute, feel free to ignore the complete PR. I am using lmdb inside Jazz and wanted to contribute something back.

1. The memory leak after realloc() is just good enough to pass cppcheck. It may not be the a complete fix or the best fix.
2. The complete cppcheck pass requires to also remove the block:
```
#if (BYTE_ORDER == LITTLE_ENDIAN) == (BYTE_ORDER == BIG_ENDIAN)
# error "Unknown or unsupported endianness (BYTE_ORDER)"
#elif (-6 & 5) || CHAR_BIT!=8 || UINT_MAX!=0xffffffff || MDB_SIZE_MAX%UINT_MAX
# error "Two's complement, reasonably sized integer types, please"
#endif
```
because that produces a preprocessor error that prevents the check from completing. (I didn't do it here because it felt too bold.)
